### PR TITLE
properly check for already installed NASM executable in the %NASMPATH%

### DIFF
--- a/install_script.bat
+++ b/install_script.bat
@@ -3,7 +3,7 @@ setlocal
 
 REM Defined cript variables
 set NASMDL=http://www.nasm.us/pub/nasm/releasebuilds
-set NASMVERSION=2.16
+set NASMVERSION=2.16.01
 set VSWHEREDL=https://github.com/Microsoft/vswhere/releases/download
 set VSWHEREVERSION=2.8.4
 
@@ -314,6 +314,12 @@ if exist "%SCRIPTDIR%\nasm_%NASMVERSION%.zip" (
     echo Using existing NASM binary...
     goto InstallNASM
 )
+echo Checking for existing NASM in NASMPATH...
+%NASMPATH%\nasm.exe -v
+if ERRORLEVEL 0 (
+    echo Using existing NASM binary from %NASMPATH%...
+    goto SkipInstallNASM
+)
 set NASMDOWNLOAD=%NASMDL%/%NASMVERSION%/win%SYSARCH%/nasm-%NASMVERSION%-win%SYSARCH%.zip
 echo Downloading required NASM release binary...
 powershell.exe -Command (New-Object Net.WebClient).DownloadFile('%NASMDOWNLOAD%', '%SCRIPTDIR%\nasm_%NASMVERSION%.zip') >nul 2>&1
@@ -342,6 +348,7 @@ if %ERRORLEVEL% neq 0 (
     goto Terminate
 )
 rd /S /Q "%SCRIPTDIR%\TempNASMUnpack" >nul 2>&1
+:SkipInstallNASM
 echo Finished Successfully
 goto Exit
 

--- a/nasm.props
+++ b/nasm.props
@@ -11,8 +11,8 @@
   <ItemDefinitionGroup>
     <NASM>
       <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
-      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(NasmPath)"nasm.exe -Xvc -f win32 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
-      <CommandLineTemplate Condition="'$(Platform)' == 'x64'">"$(NasmPath)"nasm.exe -Xvc -f win64 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(NasmPath)nasm.exe" -Xvc -f win32 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'x64'">"$(NasmPath)nasm.exe" -Xvc -f win64 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
       <CommandLineTemplate Condition="'$(Platform)' != 'Win32' and '$(Platform)' != 'x64'">echo NASM not supported on this platform
 exit 1</CommandLineTemplate>
       <ExecutionDescription>%(Identity)</ExecutionDescription>


### PR DESCRIPTION
- properly check for already installed NASM executable in the %NASMPATH% path, e.g. NASMPATH=C:\Program Files\NASM\
- update the NASM executable sought to the latest NASM release
- fixed NASM exec error on MSVC (2022 / v17.16.2)

These patches made NASM work again on a fresh install of MSVC on a new system with fresh Win10 22H2 install, so I expect this to work well for others too.

Used here: https://github.com/GerHobbelt/qiqqa_tooling_devtree_snapshots/blob/main/DEVELOPERS-README.md#nasm-assembler--visual-studio-add-on

