### PR TITLE
Fix incorrect NASM install skipping logic.

### DIFF
--- a/install_script.bat
+++ b/install_script.bat
@@ -309,16 +309,19 @@ if %ERRORLEVEL% neq 0 (
     echo    Ensure that this script is run in a shell with the necessary write privileges
     goto Terminate
 )
-REM Download the latest nasm binary for windows
-if exist "%SCRIPTDIR%\nasm_%NASMVERSION%.zip" (
-    echo Using existing NASM binary...
-    goto InstallNASM
-)
+REM Check if nasm is alredy found before trying to download it
 echo Checking for existing NASM in NASMPATH...
 %NASMPATH%\nasm.exe -v >nul 2>&1
-if ERRORLEVEL 0 (
+if %ERRORLEVEL% equ 0 (
     echo Using existing NASM binary from %NASMPATH%...
     goto SkipInstallNASM
+) else (
+    echo ..existing NASM not found in NASMPATH.
+)
+REM Download the latest nasm binary for windows
+if exist "%SCRIPTDIR%\nasm_%NASMVERSION%.zip" (
+    echo Using existing NASM archive...
+    goto InstallNASM
 )
 set NASMDOWNLOAD=%NASMDL%/%NASMVERSION%/win%SYSARCH%/nasm-%NASMVERSION%-win%SYSARCH%.zip
 echo Downloading required NASM release binary...


### PR DESCRIPTION
Fix two issues with the skip-NASM-install-if-exists-in-`%NASMPATH%`-logic:

1. Installing NASM binaries doesn't work at all (the use existing exe path is always taken, regardless of whether the env var is set or the exe exists).
2. The skip-install path is skipped if the nasm archive has been downloaded and exists on disk.