### PR TITLE
Improve checking for existing NASM instance

### DIFF
--- a/install_script.bat
+++ b/install_script.bat
@@ -311,7 +311,7 @@ if %ERRORLEVEL% neq 0 (
 )
 REM Check if nasm is alredy found before trying to download it
 echo Checking for existing NASM in NASMPATH...
-%NASMPATH%\nasm.exe -v >nul 2>&1
+"%NASMPATH%\nasm.exe" -v >nul 2>&1
 if %ERRORLEVEL% equ 0 (
     echo Using existing NASM binary from %NASMPATH%...
     goto SkipInstallNASM


### PR DESCRIPTION
It will now properly checks in folders with spaces and special characters without needing quotation marks ("").

Basically, this change doesnt force the user to set the `NASMPATH` variable to the path with surrounding quotes:
```diff
- NASMPATH="C:\Program Files\NASM"
+ NASMPATH=C:\Program Files\NASM
```
