### PR TITLE
Make `nasm.props` consistent with the `install_script.bat` script

### DIFF
--- a/nasm.props
+++ b/nasm.props
@@ -11,8 +11,8 @@
   <ItemDefinitionGroup>
     <NASM>
       <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
-      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(NasmPath)nasm.exe" -Xvc -f win32 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
-      <CommandLineTemplate Condition="'$(Platform)' == 'x64'">"$(NasmPath)nasm.exe" -Xvc -f win64 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'Win32'">"$(NasmPath)\nasm.exe" -Xvc -f win32 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
+      <CommandLineTemplate Condition="'$(Platform)' == 'x64'">"$(NasmPath)\nasm.exe" -Xvc -f win64 [AllOptions] [AdditionalOptions] "%(FullPath)"</CommandLineTemplate>
       <CommandLineTemplate Condition="'$(Platform)' != 'Win32' and '$(Platform)' != 'x64'">echo NASM not supported on this platform
 exit 1</CommandLineTemplate>
       <ExecutionDescription>%(Identity)</ExecutionDescription>


### PR DESCRIPTION
As in the title. Current `install_script.bat` script takes in `%NASMPATH%` **without** the trailing `\`, however `nasm.props` assumes `$(NasmPath)` (`%NASMPATH%`) does have the trailing `\`.
```diff
- $(NasmPath)nasm.exe
+ $(NasmPath)\nasm.exe
```
